### PR TITLE
Added WindowsPrivilegeDeescalation example

### DIFF
--- a/WindowsExamples.sln
+++ b/WindowsExamples.sln
@@ -7,6 +7,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NativeAPIProcessList", "Nat
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "KernelModuleEnumarationDriver", "KernelModuleEnumarationDriver\KernelModuleEnumarationDriver.vcxproj", "{C01918ED-06ED-4B2F-BDE2-3B7B22958EE2}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WindowsPrivilegeDeescalation", "WindowsPrivilegeDeescalation\WindowsPrivilegeDeescalation.vcxproj", "{51E788A7-2D44-4A09-BAC4-9C247AC4AEFD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -47,6 +49,18 @@ Global
 		{C01918ED-06ED-4B2F-BDE2-3B7B22958EE2}.Release|x86.ActiveCfg = Release|x64
 		{C01918ED-06ED-4B2F-BDE2-3B7B22958EE2}.Release|x86.Build.0 = Release|x64
 		{C01918ED-06ED-4B2F-BDE2-3B7B22958EE2}.Release|x86.Deploy.0 = Release|x64
+		{51E788A7-2D44-4A09-BAC4-9C247AC4AEFD}.Debug|ARM64.ActiveCfg = Debug|x64
+		{51E788A7-2D44-4A09-BAC4-9C247AC4AEFD}.Debug|ARM64.Build.0 = Debug|x64
+		{51E788A7-2D44-4A09-BAC4-9C247AC4AEFD}.Debug|x64.ActiveCfg = Debug|x64
+		{51E788A7-2D44-4A09-BAC4-9C247AC4AEFD}.Debug|x64.Build.0 = Debug|x64
+		{51E788A7-2D44-4A09-BAC4-9C247AC4AEFD}.Debug|x86.ActiveCfg = Debug|Win32
+		{51E788A7-2D44-4A09-BAC4-9C247AC4AEFD}.Debug|x86.Build.0 = Debug|Win32
+		{51E788A7-2D44-4A09-BAC4-9C247AC4AEFD}.Release|ARM64.ActiveCfg = Release|x64
+		{51E788A7-2D44-4A09-BAC4-9C247AC4AEFD}.Release|ARM64.Build.0 = Release|x64
+		{51E788A7-2D44-4A09-BAC4-9C247AC4AEFD}.Release|x64.ActiveCfg = Release|x64
+		{51E788A7-2D44-4A09-BAC4-9C247AC4AEFD}.Release|x64.Build.0 = Release|x64
+		{51E788A7-2D44-4A09-BAC4-9C247AC4AEFD}.Release|x86.ActiveCfg = Release|Win32
+		{51E788A7-2D44-4A09-BAC4-9C247AC4AEFD}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WindowsPrivilegeDeescalation/WindowsPrivilegeDeescalation.vcxproj
+++ b/WindowsPrivilegeDeescalation/WindowsPrivilegeDeescalation.vcxproj
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{51e788a7-2d44-4a09-bac4-9c247ac4aefd}</ProjectGuid>
+    <RootNamespace>WindowsPrivilegeDeescalation</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <UACExecutionLevel>AsInvoker</UACExecutionLevel>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <UACExecutionLevel>AsInvoker</UACExecutionLevel>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <UACExecutionLevel>AsInvoker</UACExecutionLevel>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <UACExecutionLevel>AsInvoker</UACExecutionLevel>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/WindowsPrivilegeDeescalation/WindowsPrivilegeDeescalation.vcxproj.filters
+++ b/WindowsPrivilegeDeescalation/WindowsPrivilegeDeescalation.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/WindowsPrivilegeDeescalation/main.cpp
+++ b/WindowsPrivilegeDeescalation/main.cpp
@@ -1,0 +1,122 @@
+#include <iostream>
+#include <tchar.h>
+#include <Windows.h>
+#include <TlHelp32.h>
+
+
+DWORD GetProcessId(const TCHAR* szProcessName)
+{
+    DWORD dwProcessId{ 0 };
+    HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+
+    if (hSnapshot != INVALID_HANDLE_VALUE)
+    {
+        PROCESSENTRY32 pe32;
+        pe32.dwSize = sizeof(pe32);
+
+        if (Process32First(hSnapshot, &pe32))
+        {
+            do
+            {
+                if (!_tcscmp(szProcessName, pe32.szExeFile))
+                {
+                    dwProcessId = pe32.th32ProcessID;
+                    break;
+                }
+            } while (Process32Next(hSnapshot, &pe32));
+        }
+        CloseHandle(hSnapshot);
+    }
+
+    return dwProcessId;
+}
+
+HANDLE RunCreateProcess(wchar_t* szApplication)
+{
+    STARTUPINFOW si{ sizeof(si) };
+    PROCESS_INFORMATION pi;
+
+    if (CreateProcessW(nullptr, szApplication, nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi))
+    {
+        _tprintf(_T("RunCreateProcess: %d\n"), pi.dwProcessId);;
+        CloseHandle(pi.hThread);
+    }
+
+    return pi.hProcess;
+}
+
+HANDLE RunCreateProcessWithLogon(wchar_t* szApplication, const wchar_t* szUsername, const wchar_t* szDomain, const wchar_t* szPassword)
+{
+    STARTUPINFOW si{ sizeof(si) };
+    PROCESS_INFORMATION pi;
+
+    if (CreateProcessWithLogonW(szUsername, szDomain, szPassword, LOGON_WITH_PROFILE, nullptr, szApplication, 0, nullptr, nullptr, &si, &pi))
+    {
+        _tprintf(_T("RunCreateProcessWithLogon: %d\n"), pi.dwProcessId);
+        CloseHandle(pi.hThread);
+    }
+    return pi.hProcess;
+}
+
+HANDLE RunCreateProcessWithToken(wchar_t* szApplication)
+{
+    STARTUPINFOW si{ sizeof(si) };
+    PROCESS_INFORMATION pi;
+
+    HANDLE hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, GetProcessId(_T("explorer.exe")));
+    HANDLE hToken = nullptr;
+    if (OpenProcessToken(hProcess, TOKEN_ALL_ACCESS, &hToken))
+    {
+        HANDLE hImpersonationToken = nullptr;
+        if (DuplicateTokenEx(hToken, TOKEN_ALL_ACCESS, nullptr, SecurityImpersonation, TokenImpersonation, &hImpersonationToken))
+        {
+            if (CreateProcessWithTokenW(hImpersonationToken, 0, nullptr, szApplication, 0, nullptr, nullptr, &si, &pi))
+            {
+                _tprintf(_T("RunCreateProcessWithToken: %d\n"), pi.dwProcessId);
+                CloseHandle(pi.hThread);
+            }
+            CloseHandle(hImpersonationToken);
+        }
+        CloseHandle(hToken);
+    }
+
+    return pi.hProcess;
+}
+
+int _tmain(int argc, const TCHAR* argv[], const TCHAR* env[])
+{
+    if (argc != 2)
+    {
+        _tprintf(_T("Usage: WindowsPrivilegeDeescalation.exe <application_path>\n"));
+        return -1;
+    }
+
+    // Get Application Path
+    constexpr size_t dwApplicationPathSize = 256;
+    wchar_t szApplicationPath[dwApplicationPathSize];
+
+#ifdef UNICODE
+    wcscpy_s(szApplicationPath, argv[1]);
+#else
+    mbsrtowcs_s(nullptr, szApplicationPath, &argv[1], dwApplicationPathSize - 1, nullptr);
+#endif
+
+    // Get Username, Domain, and Password from the environment variables
+    wchar_t szUsername[64]{ 0 }, szDomain[64]{ 0 }, szPassword[64]{ 0 };
+    GetEnvironmentVariableW(L"Username", szUsername, sizeof(szUsername) / sizeof(szUsername[0]));
+    GetEnvironmentVariableW(L"Domain", szDomain, sizeof(szDomain) / sizeof(szDomain[0]));
+    GetEnvironmentVariableW(L"Password", szPassword, sizeof(szPassword) / sizeof(szPassword[0]));
+
+    // Run functions
+    HANDLE hTableArr[3];
+    hTableArr[0] = RunCreateProcess(szApplicationPath);
+    hTableArr[1] = RunCreateProcessWithLogon(szApplicationPath, szUsername, szDomain, szPassword);
+    hTableArr[2] = RunCreateProcessWithToken(szApplicationPath);
+
+    // Wait for processes to finish
+    WaitForSingleObject(hTableArr[0], INFINITE); CloseHandle(hTableArr[0]);
+    WaitForSingleObject(hTableArr[1], INFINITE); CloseHandle(hTableArr[1]);
+    WaitForSingleObject(hTableArr[2], INFINITE); CloseHandle(hTableArr[2]);
+
+    return 0;
+}


### PR DESCRIPTION
### Added Windows Privilege De-escalation Example

- Create process as standard user from an elevated process
- Set `Username`, `Domain`, and `Password` environment variables for `CreateProcessWithLogon` function to work correctly
- Run application as elevated for `CreateProcessWithToken` to function correctly